### PR TITLE
fix(ci): Copilot PR undraft, CI gate, and ready_for_review

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   unit-tests:

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,5 @@
-# Merges any pull request after "Android CI" succeeds.
+# Merges any pull request after "Android CI" succeeds for the same commit as the PR head
+# (head SHA must match the workflow run; avoids merging if the branch moved after CI).
 # Branch protection: if merges are blocked (required reviewers), add repository secret
 # COPILOT_MERGE_PAT — a fine-grained PAT with Contents and Pull requests (write), or
 # classic PAT with repo scope — and relax or bypass rules as appropriate for your org.
@@ -59,9 +60,24 @@ jobs:
               if (pr.state !== 'open' || pr.merged) {
                 continue;
               }
+              if (pr.head.sha !== run.head_sha) {
+                core.info(
+                  `PR #${num} head ${pr.head.sha.slice(0, 7)} does not match Android CI run ${String(run.head_sha).slice(0, 7)}; branch moved or run is stale — skipping merge.`,
+                );
+                continue;
+              }
               if (!mergeableBases.has(pr.base.ref)) {
                 core.info(`PR #${num} targets ${pr.base.ref}; skipping.`);
                 continue;
+              }
+              if (pr.draft) {
+                await github.rest.pulls.update({
+                  owner,
+                  repo,
+                  pull_number: num,
+                  draft: false,
+                });
+                core.info(`PR #${num} was a draft; marked ready for review before merge.`);
               }
               try {
                 await github.rest.pulls.merge({

--- a/.github/workflows/vibe-coding-ota-hints.yml
+++ b/.github/workflows/vibe-coding-ota-hints.yml
@@ -59,7 +59,7 @@ jobs:
             const custom = [
               'You are assigned from a SafePhone / vibe-coding issue. Use the title and description as the source of truth.',
               'Prefer small commits. Run checks that exist in the repo (e.g. `./gradlew :app:testStandardDebugUnitTest`).',
-              'Open a PR against the base branch below when done.',
+              'Open a PR against the base branch below when done (ready for review, not a draft).',
               '---',
               `Title: ${issue.title}`,
               '',


### PR DESCRIPTION
## Summary
- **Auto-merge**: Mark draft PRs ready for review before calling `pulls.merge` (GitHub blocks merging drafts).
- **Auto-merge**: Skip merge unless `pr.head.sha` matches the successful **Android CI** `workflow_run.head_sha` so we never merge a branch tip that was not tested by that green run.
- **Android CI**: Explicit `pull_request` types including `ready_for_review` so CI runs when a draft becomes ready.
- **Vibe coding**: Copilot instructions ask for a ready (non-draft) PR.

## Notes
Branch protection / `COPILOT_MERGE_PAT` behavior is unchanged; see comments in `.github/workflows/auto-merge.yml`.

Made with [Cursor](https://cursor.com)