### PR TITLE
feat(cloud-sync): sync policy across devices via GitHub Gist with CD-injected defaults

### DIFF
--- a/.github/workflows/android-branch-apk.yml
+++ b/.github/workflows/android-branch-apk.yml
@@ -72,6 +72,11 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          # Cloud-sync defaults baked into the APK so installs don't need in-app token entry.
+          # Both secrets are optional: if either is unset, BuildConfig falls back to "" and the
+          # in-app Cloud sync screen will require manual entry instead.
+          SAFEPHONE_CLOUD_SYNC_DEFAULT_GITHUB_TOKEN: ${{ secrets.CLOUD_SYNC_DEFAULT_GITHUB_TOKEN }}
+          SAFEPHONE_CLOUD_SYNC_DEFAULT_GIST_ID: ${{ secrets.CLOUD_SYNC_DEFAULT_GIST_ID }}
         run: |
           ./gradlew :app:assembleInternalRelease --no-daemon \
             -PappVersionCode="${{ github.run_number }}" \

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,6 +44,38 @@ if (keystorePropertiesFile.exists()) {
     keystoreProperties.load(keystorePropertiesFile.inputStream())
 }
 
+/**
+ * Local-only secrets (PATs, default gist ids, etc.). Mirrors the pattern used for keystore.properties
+ * so secrets stay in [local.properties] (gitignored) and never enter source control. Gradle's
+ * `findProperty` (which reads `gradle.properties` and `-P` flags) is consulted as a fallback so CI
+ * can still inject these values via `-Psafephone.cloudSyncDefaultGitHubToken=...`.
+ */
+val localProperties = Properties()
+val localPropertiesFile = rootProject.file("local.properties")
+if (localPropertiesFile.exists()) {
+    localProperties.load(localPropertiesFile.inputStream())
+}
+
+fun org.gradle.api.Project.localOrProperty(name: String): String {
+    val fromLocal = localProperties.getProperty(name)?.trim().orEmpty()
+    if (fromLocal.isNotEmpty()) return fromLocal
+    return (findProperty(name) as String?)?.trim().orEmpty()
+}
+
+/**
+ * Resolves a build-time secret in this priority order:
+ * 1. Environment variable [envName] (preferred for CI — secrets stay out of the gradle command line),
+ * 2. `local.properties` value of [propertyName],
+ * 3. Gradle project property [propertyName] (so `-P` overrides still work for ad-hoc builds).
+ *
+ * Returns an empty string when none of the sources are set, so the BuildConfig literal is `""`.
+ */
+fun org.gradle.api.Project.envOrLocalOrProperty(envName: String, propertyName: String): String {
+    val fromEnv = System.getenv(envName)?.trim().orEmpty()
+    if (fromEnv.isNotEmpty()) return fromEnv
+    return localOrProperty(propertyName)
+}
+
 val appVersionCode = (findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 1
 val appVersionName = (findProperty("appVersionName") as String?)?.trim().orEmpty().ifEmpty { "0.1.0" }
 
@@ -62,6 +94,25 @@ android {
         val (ghIssuesOwner, ghIssuesRepo) = githubIssuesOwnerRepo()
         buildConfigField("String", "GITHUB_ISSUES_OWNER", ghIssuesOwner.toBuildConfigStringLiteral())
         buildConfigField("String", "GITHUB_ISSUES_REPO", ghIssuesRepo.toBuildConfigStringLiteral())
+
+        val cloudSyncToken = envOrLocalOrProperty(
+            envName = "SAFEPHONE_CLOUD_SYNC_DEFAULT_GITHUB_TOKEN",
+            propertyName = "safephone.cloudSyncDefaultGitHubToken",
+        )
+        val cloudSyncGistId = envOrLocalOrProperty(
+            envName = "SAFEPHONE_CLOUD_SYNC_DEFAULT_GIST_ID",
+            propertyName = "safephone.cloudSyncDefaultGistId",
+        )
+        buildConfigField(
+            "String",
+            "CLOUD_SYNC_DEFAULT_GITHUB_TOKEN",
+            cloudSyncToken.toBuildConfigStringLiteral(),
+        )
+        buildConfigField(
+            "String",
+            "CLOUD_SYNC_DEFAULT_GIST_ID",
+            cloudSyncGistId.toBuildConfigStringLiteral(),
+        )
     }
     testOptions {
         @Suppress("DEPRECATION")

--- a/app/src/main/java/com/safephone/SafePhoneApp.kt
+++ b/app/src/main/java/com/safephone/SafePhoneApp.kt
@@ -1,7 +1,9 @@
 package com.safephone
 
 import android.app.Application
+import com.safephone.cloud.CloudSyncManager
 import com.safephone.data.AppDatabase
+import com.safephone.data.CloudSyncPreferences
 import com.safephone.data.FocusPreferences
 import com.safephone.data.seedDatabaseIfEmpty
 import com.safephone.service.CalendarWatcher
@@ -20,22 +22,32 @@ class SafePhoneApp : Application() {
         private set
     lateinit var prefs: FocusPreferences
         private set
+    lateinit var cloudSyncPrefs: CloudSyncPreferences
+        private set
     lateinit var usageStatsRepository: UsageStatsRepository
         private set
     lateinit var calendarWatcher: CalendarWatcher
         private set
     lateinit var policyAssembler: PolicyAssembler
         private set
+    lateinit var cloudSyncManager: CloudSyncManager
+        private set
 
     override fun onCreate() {
         super.onCreate()
         database = AppDatabase.getInstance(this)
         prefs = FocusPreferences(this)
+        cloudSyncPrefs = CloudSyncPreferences(this)
         usageStatsRepository = UsageStatsRepository(this)
         calendarWatcher = CalendarWatcher(this)
         policyAssembler = PolicyAssembler(database, prefs, usageStatsRepository, calendarWatcher)
+        cloudSyncManager = CloudSyncManager(database, prefs, cloudSyncPrefs, appScope)
         appScope.launch(Dispatchers.IO) {
             seedDatabaseIfEmpty(database)
+            // Pull first so the change-observer's first emission already reflects remote state
+            // and we don't immediately push back what we just downloaded.
+            cloudSyncManager.pullOnLaunchIfEnabled()
+            cloudSyncManager.start()
         }
         InternalUpdateScheduler.scheduleIfNeeded(this)
     }

--- a/app/src/main/java/com/safephone/cloud/CloudSyncManager.kt
+++ b/app/src/main/java/com/safephone/cloud/CloudSyncManager.kt
@@ -1,0 +1,244 @@
+package com.safephone.cloud
+
+import com.safephone.data.AppDatabase
+import com.safephone.data.CloudSyncPreferences
+import com.safephone.data.FocusPreferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Coordinates manual and automatic cloud sync against a single GitHub Gist.
+ *
+ * Key behaviours:
+ *  - [pullNow] / [pushNow] are user-initiated; both update [status] for UI feedback.
+ *  - [start] launches a long-running observer that watches every synced field and pushes a debounced
+ *    snapshot when "auto-push on change" is enabled.
+ *  - [pullOnLaunchIfEnabled] is meant to run once after process start, before the user touches the UI.
+ *  - All push paths skip a write when the captured snapshot is byte-identical to the last known
+ *    remote payload, so noisy Flow emissions don't spam GitHub.
+ *  - During [pullNow] we set a watermark that suppresses the auto-push observer so the writes from
+ *    [PolicySnapshotRepository.apply] don't immediately bounce back as a new push.
+ */
+@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+class CloudSyncManager(
+    db: AppDatabase,
+    private val focusPrefs: FocusPreferences,
+    private val cloudPrefs: CloudSyncPreferences,
+    private val parentScope: CoroutineScope,
+    private val snapshotRepo: PolicySnapshotRepository = PolicySnapshotRepository(db, focusPrefs),
+    private val gistClientFactory: (String) -> GistClient = ::GistClient,
+    private val nowMs: () -> Long = System::currentTimeMillis,
+) {
+    private val scope = CoroutineScope(parentScope.coroutineContext + SupervisorJob())
+    private val pushMutex = Mutex()
+    private val pullMutex = Mutex()
+
+    @Volatile private var observerJob: Job? = null
+    @Volatile private var lastUploadedJson: String? = null
+    @Volatile private var suppressAutoPushUntilMs: Long = 0L
+
+    private val _status = MutableStateFlow<CloudSyncStatus>(CloudSyncStatus.Idle)
+    val status: StateFlow<CloudSyncStatus> = _status.asStateFlow()
+
+    private val daos = SyncedDaos(db)
+
+    /** Starts the change-observer. Safe to call multiple times — second call is a no-op. */
+    fun start() {
+        if (observerJob != null) return
+        observerJob = scope.launch {
+            // Combine every observable input that contributes to the policy. Any change emits.
+            val sources: List<Flow<Any?>> = listOf(
+                daos.profiles,
+                daos.blockedApps,
+                daos.domainRules,
+                daos.appBudgets,
+                daos.breakPolicy,
+                daos.calendarKeywords,
+                focusPrefs.enforcementEnabled,
+                focusPrefs.activeProfileId,
+                focusPrefs.aggressivePoll,
+                focusPrefs.notificationHints,
+                focusPrefs.calendarAware,
+                focusPrefs.mindfulFrictionPackages,
+                focusPrefs.systemMonochromeAutomationEnabled,
+                focusPrefs.socialMediaCategoryBlocked,
+                focusPrefs.partnerBlockAlertEnabled,
+                focusPrefs.partnerBlockAlertThreshold,
+                focusPrefs.partnerAlertPhoneDigits,
+                focusPrefs.activeDaysOfWeek,
+            )
+            combine(sources) { _ -> Unit }
+                .drop(1) // skip the snapshot emitted on subscription
+                .debounce(AUTO_PUSH_DEBOUNCE_MS)
+                .mapLatest { _ ->
+                    val snap = cloudPrefs.snapshot()
+                    val autoPush = cloudPrefs.autoPushOnChange.first()
+                    if (!autoPush || !snap.isConfigured) return@mapLatest
+                    if (nowMs() < suppressAutoPushUntilMs) return@mapLatest
+                    pushNowInternal(reason = SyncTrigger.Auto)
+                }
+                .collect { /* side effects only */ }
+        }
+    }
+
+    /** Cancels the change-observer (e.g. when the process scope is being torn down in tests). */
+    fun stop() {
+        observerJob?.cancel()
+        observerJob = null
+    }
+
+    suspend fun pullOnLaunchIfEnabled() {
+        val snap = cloudPrefs.snapshot()
+        if (!snap.isConfigured || !snap.autoPullOnLaunch) return
+        if (snap.gistId.isBlank()) return
+        pullNow()
+    }
+
+    suspend fun pullNow(): CloudSyncStatus = pullMutex.withLock {
+        val snap = cloudPrefs.snapshot()
+        if (!snap.isConfigured) {
+            return@withLock setStatus(CloudSyncStatus.Failure("Add a GitHub token first"))
+        }
+        if (snap.gistId.isBlank()) {
+            return@withLock setStatus(CloudSyncStatus.Failure("No gist id yet — push once to create one"))
+        }
+        setStatus(CloudSyncStatus.InProgress(SyncDirection.Pull))
+        val client = gistClientFactory(snap.gitHubToken)
+        when (val res = client.readGist(snap.gistId)) {
+            is GistClient.GistResult.Failure -> {
+                val msg = formatHttpError("pull", res.httpCode, res.message)
+                cloudPrefs.recordSyncResult(nowMs(), DIR_PULL, "Failed: $msg")
+                setStatus(CloudSyncStatus.Failure(msg))
+            }
+            is GistClient.GistResult.Success -> {
+                val parsed = snapshotRepo.fromJson(res.value.content)
+                if (parsed == null) {
+                    cloudPrefs.recordSyncResult(nowMs(), DIR_PULL, "Failed: invalid JSON")
+                    return@withLock setStatus(CloudSyncStatus.Failure("Remote payload was not valid JSON"))
+                }
+                // Suppress the auto-push observer for a window covering the apply + DataStore commit
+                // so we don't immediately re-push what we just downloaded.
+                suppressAutoPushUntilMs = nowMs() + APPLY_SUPPRESS_MS
+                val applyResult = snapshotRepo.apply(parsed)
+                if (applyResult is PolicySnapshotRepository.ApplyResult.SchemaTooNew) {
+                    val msg = "Remote uses schema v${applyResult.remoteVersion}; update SafePhone"
+                    cloudPrefs.recordSyncResult(nowMs(), DIR_PULL, "Failed: $msg")
+                    return@withLock setStatus(CloudSyncStatus.Failure(msg))
+                }
+                lastUploadedJson = res.value.content
+                cloudPrefs.recordSyncResult(nowMs(), DIR_PULL, "Pulled snapshot")
+                setStatus(CloudSyncStatus.Success(SyncDirection.Pull, "Pulled snapshot"))
+            }
+        }
+    }
+
+    suspend fun pushNow(): CloudSyncStatus = pushNowInternal(SyncTrigger.Manual)
+
+    private suspend fun pushNowInternal(reason: SyncTrigger): CloudSyncStatus = pushMutex.withLock {
+        val snap = cloudPrefs.snapshot()
+        if (!snap.isConfigured) {
+            return@withLock if (reason == SyncTrigger.Manual) {
+                setStatus(CloudSyncStatus.Failure("Add a GitHub token first"))
+            } else {
+                _status.value
+            }
+        }
+        if (reason == SyncTrigger.Manual) {
+            setStatus(CloudSyncStatus.InProgress(SyncDirection.Push))
+        }
+        val deviceId = cloudPrefs.deviceId()
+        val snapshot = snapshotRepo.capture(deviceId, nowMs())
+        val json = snapshotRepo.toJson(snapshot)
+
+        // Avoid pointless writes when nothing actually changed since the last successful push/pull.
+        if (json == lastUploadedJson && reason == SyncTrigger.Auto) return@withLock _status.value
+
+        val client = gistClientFactory(snap.gitHubToken)
+        val gistId = snap.gistId
+        return@withLock if (gistId.isBlank()) {
+            when (val res = client.createGist(json)) {
+                is GistClient.GistResult.Failure -> {
+                    val msg = formatHttpError("push", res.httpCode, res.message)
+                    cloudPrefs.recordSyncResult(nowMs(), DIR_PUSH, "Failed: $msg")
+                    setStatus(CloudSyncStatus.Failure(msg))
+                }
+                is GistClient.GistResult.Success -> {
+                    cloudPrefs.setGistId(res.value)
+                    lastUploadedJson = json
+                    cloudPrefs.recordSyncResult(nowMs(), DIR_PUSH, "Created gist ${res.value.take(8)}…")
+                    setStatus(CloudSyncStatus.Success(SyncDirection.Push, "Pushed (created gist)"))
+                }
+            }
+        } else {
+            when (val res = client.updateGist(gistId, json)) {
+                is GistClient.GistResult.Failure -> {
+                    val msg = formatHttpError("push", res.httpCode, res.message)
+                    cloudPrefs.recordSyncResult(nowMs(), DIR_PUSH, "Failed: $msg")
+                    setStatus(CloudSyncStatus.Failure(msg))
+                }
+                is GistClient.GistResult.Success -> {
+                    lastUploadedJson = json
+                    cloudPrefs.recordSyncResult(nowMs(), DIR_PUSH, "Pushed snapshot")
+                    setStatus(CloudSyncStatus.Success(SyncDirection.Push, "Pushed snapshot"))
+                }
+            }
+        }
+    }
+
+    private fun setStatus(s: CloudSyncStatus): CloudSyncStatus {
+        _status.value = s
+        return s
+    }
+
+    private fun formatHttpError(action: String, code: Int, body: String): String = when (code) {
+        -1 -> "Could not reach GitHub during $action: $body"
+        401 -> "GitHub rejected the token (check the gist scope)"
+        403 -> "GitHub rate-limit or permission error"
+        404 -> "Gist not found — clear the gist id to create a new one"
+        else -> "GitHub $action failed (HTTP $code): $body"
+    }
+
+    private enum class SyncTrigger { Manual, Auto }
+
+    companion object {
+        private const val AUTO_PUSH_DEBOUNCE_MS = 5_000L
+        private const val APPLY_SUPPRESS_MS = 10_000L
+        private const val DIR_PUSH = "push"
+        private const val DIR_PULL = "pull"
+    }
+}
+
+/** Direction of the most recent sync attempt, surfaced to the UI. */
+enum class SyncDirection { Push, Pull }
+
+/** State machine surfaced to UI; new states should remain additive. */
+sealed class CloudSyncStatus {
+    data object Idle : CloudSyncStatus()
+    data class InProgress(val direction: SyncDirection) : CloudSyncStatus()
+    data class Success(val direction: SyncDirection, val message: String) : CloudSyncStatus()
+    data class Failure(val message: String) : CloudSyncStatus()
+}
+
+private class SyncedDaos(db: AppDatabase) {
+    val profiles = db.focusProfileDao().observeAll()
+    val blockedApps = db.blockedAppDao().observeAll()
+    val domainRules = db.domainRuleDao().observeAll()
+    val appBudgets = db.appBudgetDao().observeAll()
+    val breakPolicy = db.breakPolicyDao().observe()
+    val calendarKeywords = db.calendarKeywordDao().observeAll()
+}

--- a/app/src/main/java/com/safephone/cloud/GistClient.kt
+++ b/app/src/main/java/com/safephone/cloud/GistClient.kt
@@ -1,0 +1,191 @@
+package com.safephone.cloud
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * Minimal client for the GitHub Gist REST API.
+ *
+ * Uses [HttpURLConnection] (matching the existing pattern in [com.safephone.update.InternalUpdateWorker])
+ * to avoid pulling in OkHttp just for one feature. The API surface is intentionally narrow:
+ *  - [readGist] downloads a gist's first matching file content,
+ *  - [createGist] uploads a brand-new private gist and returns its id,
+ *  - [updateGist] overwrites an existing gist's file in place.
+ */
+class GistClient(
+    private val token: String,
+    private val userAgent: String = "SafePhone-Android",
+) {
+    private val moshi: Moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    private val createReqAdapter = moshi.adapter(CreateGistRequest::class.java)
+    private val updateReqAdapter = moshi.adapter(UpdateGistRequest::class.java)
+    private val createRespAdapter = moshi.adapter(CreateGistResponse::class.java)
+    private val readRespAdapter = moshi.adapter(ReadGistResponse::class.java)
+
+    suspend fun readGist(gistId: String, fileName: String = DEFAULT_FILE): GistResult<ReadGist> =
+        withContext(Dispatchers.IO) {
+            val url = URL("$API_BASE/gists/${gistId.trim()}")
+            val (code, body) = httpGet(url)
+            if (code !in 200..299) {
+                return@withContext GistResult.Failure(code, body.shortDescription())
+            }
+            val parsed = try {
+                readRespAdapter.fromJson(body)
+            } catch (_: Exception) {
+                null
+            }
+            val files = parsed?.files
+            if (parsed == null || files == null || files.isEmpty()) {
+                return@withContext GistResult.Failure(code, "Gist has no readable files")
+            }
+            val file = files[fileName]
+                ?: files.values.firstOrNull()
+                ?: return@withContext GistResult.Failure(code, "Gist file not found")
+            val content = file.content
+                ?: return@withContext GistResult.Failure(code, "Gist file content was empty")
+            GistResult.Success(ReadGist(content = content, updatedAt = parsed.updated_at.orEmpty()))
+        }
+
+    suspend fun createGist(
+        content: String,
+        description: String = "SafePhone policy",
+        fileName: String = DEFAULT_FILE,
+        public: Boolean = false,
+    ): GistResult<String> = withContext(Dispatchers.IO) {
+        val payload = CreateGistRequest(
+            description = description,
+            public = public,
+            files = mapOf(fileName to GistFilePayload(content = content)),
+        )
+        val (code, body) = httpJson("POST", URL("$API_BASE/gists"), createReqAdapter.toJson(payload))
+        if (code !in 200..299) {
+            return@withContext GistResult.Failure(code, body.shortDescription())
+        }
+        val id = try {
+            createRespAdapter.fromJson(body)?.id
+        } catch (_: Exception) {
+            null
+        }
+        if (id.isNullOrBlank()) {
+            GistResult.Failure(code, "Gist created but response missing id")
+        } else {
+            GistResult.Success(id)
+        }
+    }
+
+    suspend fun updateGist(
+        gistId: String,
+        content: String,
+        fileName: String = DEFAULT_FILE,
+    ): GistResult<Unit> = withContext(Dispatchers.IO) {
+        val payload = UpdateGistRequest(
+            files = mapOf(fileName to GistFilePayload(content = content)),
+        )
+        val (code, body) = httpJson(
+            "PATCH",
+            URL("$API_BASE/gists/${gistId.trim()}"),
+            updateReqAdapter.toJson(payload),
+        )
+        if (code in 200..299) GistResult.Success(Unit)
+        else GistResult.Failure(code, body.shortDescription())
+    }
+
+    private fun httpGet(url: URL): Pair<Int, String> {
+        val conn = url.openConnection() as HttpURLConnection
+        return try {
+            conn.applyCommonHeaders()
+            conn.requestMethod = "GET"
+            conn.connectTimeout = TIMEOUT_MS
+            conn.readTimeout = TIMEOUT_MS
+            val code = conn.responseCode
+            val body = conn.readBodySafely(code)
+            code to body
+        } catch (e: IOException) {
+            -1 to (e.message ?: "I/O error")
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    private fun httpJson(method: String, url: URL, json: String): Pair<Int, String> {
+        val conn = url.openConnection() as HttpURLConnection
+        return try {
+            conn.applyCommonHeaders()
+            // PATCH isn't always honored by HttpURLConnection; fall back to POST + override header.
+            if (method == "PATCH") {
+                conn.requestMethod = "POST"
+                conn.setRequestProperty("X-HTTP-Method-Override", "PATCH")
+            } else {
+                conn.requestMethod = method
+            }
+            conn.doOutput = true
+            conn.setRequestProperty("Content-Type", "application/json; charset=utf-8")
+            conn.connectTimeout = TIMEOUT_MS
+            conn.readTimeout = TIMEOUT_MS
+            conn.outputStream.use { os -> os.write(json.toByteArray(Charsets.UTF_8)) }
+            val code = conn.responseCode
+            val body = conn.readBodySafely(code)
+            code to body
+        } catch (e: IOException) {
+            -1 to (e.message ?: "I/O error")
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    private fun HttpURLConnection.applyCommonHeaders() {
+        setRequestProperty("Authorization", "Bearer $token")
+        setRequestProperty("Accept", "application/vnd.github+json")
+        setRequestProperty("X-GitHub-Api-Version", "2022-11-28")
+        setRequestProperty("User-Agent", userAgent)
+    }
+
+    private fun HttpURLConnection.readBodySafely(code: Int): String {
+        val stream = if (code in 200..299) inputStream else errorStream
+        return stream?.bufferedReader(Charsets.UTF_8)?.use { it.readText() }.orEmpty()
+    }
+
+    private fun String.shortDescription(): String {
+        if (isBlank()) return "(no response body)"
+        return if (length <= 240) this else take(240) + "…"
+    }
+
+    sealed class GistResult<out T> {
+        data class Success<T>(val value: T) : GistResult<T>()
+        data class Failure(val httpCode: Int, val message: String) : GistResult<Nothing>()
+    }
+
+    data class ReadGist(val content: String, val updatedAt: String)
+
+    internal data class CreateGistRequest(
+        val description: String,
+        val public: Boolean,
+        val files: Map<String, GistFilePayload>,
+    )
+
+    internal data class UpdateGistRequest(
+        val files: Map<String, GistFilePayload>,
+    )
+
+    internal data class GistFilePayload(val content: String)
+
+    internal data class CreateGistResponse(val id: String?)
+
+    internal data class ReadGistResponse(
+        val files: Map<String, GistFileBody>?,
+        @Suppress("PropertyName") val updated_at: String?,
+    )
+
+    internal data class GistFileBody(val content: String?)
+
+    companion object {
+        const val DEFAULT_FILE: String = "safephone-policy.json"
+        private const val API_BASE = "https://api.github.com"
+        private const val TIMEOUT_MS = 15_000
+    }
+}

--- a/app/src/main/java/com/safephone/cloud/PolicySnapshot.kt
+++ b/app/src/main/java/com/safephone/cloud/PolicySnapshot.kt
@@ -1,0 +1,72 @@
+package com.safephone.cloud
+
+/**
+ * Versioned, JSON-serializable representation of the user's full policy.
+ *
+ * Synced fields cover everything that defines *what* SafePhone enforces. Per-device runtime state
+ * (onboarding flags, current break timer, daltonizer snapshot, block stats counters) is intentionally
+ * excluded so devices don't fight over each other's transient state.
+ *
+ * Bump [CURRENT_SCHEMA_VERSION] (and migrate or refuse to apply on read) for any non-additive change.
+ */
+data class PolicySnapshot(
+    val schemaVersion: Int,
+    val deviceId: String,
+    val updatedAtMs: Long,
+    val profiles: List<ProfileDto>,
+    val blockedApps: List<String>,
+    val domainRules: List<DomainRuleDto>,
+    val appBudgets: List<AppBudgetDto>,
+    val breakPolicy: BreakPolicyDto,
+    val calendarKeywords: List<String>,
+    val prefs: PrefsDto,
+) {
+    companion object {
+        const val CURRENT_SCHEMA_VERSION: Int = 1
+    }
+}
+
+data class ProfileDto(
+    val id: Long,
+    val name: String,
+    val preset: String,
+    val useTierA: Boolean,
+    val useTierB: Boolean,
+    val useTierC: Boolean,
+    val strictBrowserLock: Boolean,
+    val enforceGrayscale: Boolean,
+    val softEnforcement: Boolean,
+)
+
+data class DomainRuleDto(
+    val id: Long,
+    val pattern: String,
+    val isAllowlist: Boolean,
+)
+
+data class AppBudgetDto(
+    val packageName: String,
+    val maxMinutesPerDay: Int,
+    val maxOpensPerDay: Int,
+)
+
+data class BreakPolicyDto(
+    val maxBreaksPerDay: Int,
+    val breakDurationMinutes: Int,
+    val minGapBetweenBreaksMinutes: Int,
+)
+
+data class PrefsDto(
+    val enforcementEnabled: Boolean,
+    val activeProfileId: Long?,
+    val aggressivePoll: Boolean,
+    val notificationHints: Boolean,
+    val calendarAware: Boolean,
+    val mindfulFrictionPackages: List<String>,
+    val systemMonochromeAutomationEnabled: Boolean,
+    val socialMediaCategoryBlocked: Boolean,
+    val partnerBlockAlertEnabled: Boolean,
+    val partnerBlockAlertThreshold: Int,
+    val partnerAlertPhoneDigits: String,
+    val activeDaysOfWeek: List<Int>,
+)

--- a/app/src/main/java/com/safephone/cloud/PolicySnapshotRepository.kt
+++ b/app/src/main/java/com/safephone/cloud/PolicySnapshotRepository.kt
@@ -1,0 +1,190 @@
+package com.safephone.cloud
+
+import com.safephone.data.AppBudgetEntity
+import com.safephone.data.AppDatabase
+import com.safephone.data.BlockedAppEntity
+import com.safephone.data.BreakPolicyEntity
+import com.safephone.data.CalendarKeywordEntity
+import com.safephone.data.DomainRuleEntity
+import com.safephone.data.FocusPreferences
+import com.safephone.data.FocusProfileEntity
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+
+/**
+ * Captures the local policy into a [PolicySnapshot] (for upload) and applies a remote snapshot back
+ * onto the local database + preferences (for download).
+ *
+ * `apply()` uses replace-all semantics so the device ends up byte-identical to the remote snapshot
+ * for synced fields. This intentionally clobbers local edits — call sites are expected to confirm
+ * with the user (or to suppress observers during apply, see [com.safephone.cloud.CloudSyncManager]).
+ */
+class PolicySnapshotRepository(
+    private val db: AppDatabase,
+    private val prefs: FocusPreferences,
+) {
+    private val moshi: Moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+
+    private val adapter: JsonAdapter<PolicySnapshot> =
+        moshi.adapter(PolicySnapshot::class.java).indent("  ")
+
+    fun toJson(snapshot: PolicySnapshot): String = adapter.toJson(snapshot)
+
+    /** Returns null when the JSON is malformed or omits required fields. */
+    fun fromJson(json: String): PolicySnapshot? = try {
+        adapter.fromJson(json)
+    } catch (_: Exception) {
+        null
+    }
+
+    suspend fun capture(deviceId: String, nowMs: Long): PolicySnapshot = withContext(Dispatchers.IO) {
+        val profiles = db.focusProfileDao().getAll().map { it.toDto() }
+        val blocked = db.blockedAppDao().getAll().map { it.packageName }.sorted()
+        val domains = db.domainRuleDao().getAll().map { it.toDto() }
+        val budgets = db.appBudgetDao().getAll().map { it.toDto() }
+            .sortedBy { it.packageName }
+        val breakPolicy = (db.breakPolicyDao().get() ?: BreakPolicyEntity()).toDto()
+        val keywords = db.calendarKeywordDao().getAll().map { it.keyword }.sorted()
+
+        val prefsDto = PrefsDto(
+            enforcementEnabled = prefs.enforcementEnabled.first(),
+            activeProfileId = prefs.activeProfileId.first(),
+            aggressivePoll = prefs.aggressivePoll.first(),
+            notificationHints = prefs.notificationHints.first(),
+            calendarAware = prefs.calendarAware.first(),
+            mindfulFrictionPackages = prefs.mindfulFrictionPackages.first().sorted(),
+            systemMonochromeAutomationEnabled = prefs.systemMonochromeAutomationEnabled.first(),
+            socialMediaCategoryBlocked = prefs.socialMediaCategoryBlocked.first(),
+            partnerBlockAlertEnabled = prefs.partnerBlockAlertEnabled.first(),
+            partnerBlockAlertThreshold = prefs.partnerBlockAlertThreshold.first(),
+            partnerAlertPhoneDigits = prefs.partnerAlertPhoneDigits.first(),
+            activeDaysOfWeek = prefs.activeDaysOfWeek.first().sorted(),
+        )
+
+        PolicySnapshot(
+            schemaVersion = PolicySnapshot.CURRENT_SCHEMA_VERSION,
+            deviceId = deviceId,
+            updatedAtMs = nowMs,
+            profiles = profiles,
+            blockedApps = blocked,
+            domainRules = domains,
+            appBudgets = budgets,
+            breakPolicy = breakPolicy,
+            calendarKeywords = keywords,
+            prefs = prefsDto,
+        )
+    }
+
+    suspend fun apply(snapshot: PolicySnapshot): ApplyResult = withContext(Dispatchers.IO) {
+        if (snapshot.schemaVersion > PolicySnapshot.CURRENT_SCHEMA_VERSION) {
+            return@withContext ApplyResult.SchemaTooNew(snapshot.schemaVersion)
+        }
+
+        db.focusProfileDao().deleteAll()
+        snapshot.profiles.forEach { dto -> db.focusProfileDao().insert(dto.toEntity()) }
+
+        db.blockedAppDao().deleteAll()
+        snapshot.blockedApps.forEach { pkg -> db.blockedAppDao().upsert(BlockedAppEntity(pkg)) }
+
+        db.domainRuleDao().deleteAll()
+        snapshot.domainRules.forEach { dto -> db.domainRuleDao().upsert(dto.toEntity()) }
+
+        db.appBudgetDao().deleteAll()
+        snapshot.appBudgets.forEach { dto -> db.appBudgetDao().upsert(dto.toEntity()) }
+
+        db.breakPolicyDao().upsert(snapshot.breakPolicy.toEntity())
+
+        db.calendarKeywordDao().deleteAll()
+        snapshot.calendarKeywords.forEach { kw ->
+            db.calendarKeywordDao().upsert(CalendarKeywordEntity(kw))
+        }
+
+        val p = snapshot.prefs
+        prefs.setEnforcementEnabled(p.enforcementEnabled)
+        prefs.setActiveProfileId(p.activeProfileId)
+        prefs.setAggressivePoll(p.aggressivePoll)
+        prefs.setNotificationHints(p.notificationHints)
+        prefs.setCalendarAware(p.calendarAware)
+        prefs.setMindfulFrictionPackages(p.mindfulFrictionPackages.toSet())
+        prefs.setSystemMonochromeAutomationEnabled(p.systemMonochromeAutomationEnabled)
+        prefs.setSocialMediaCategoryBlocked(p.socialMediaCategoryBlocked)
+        prefs.setPartnerBlockAlertEnabled(p.partnerBlockAlertEnabled)
+        prefs.setPartnerBlockAlertThreshold(p.partnerBlockAlertThreshold)
+        prefs.setPartnerAlertPhoneDigits(p.partnerAlertPhoneDigits)
+        prefs.setActiveDaysOfWeek(p.activeDaysOfWeek.toSet())
+
+        ApplyResult.Applied
+    }
+
+    sealed class ApplyResult {
+        data object Applied : ApplyResult()
+        data class SchemaTooNew(val remoteVersion: Int) : ApplyResult()
+    }
+}
+
+private fun FocusProfileEntity.toDto() = ProfileDto(
+    id = id,
+    name = name,
+    preset = preset,
+    useTierA = useTierA,
+    useTierB = useTierB,
+    useTierC = useTierC,
+    strictBrowserLock = strictBrowserLock,
+    enforceGrayscale = enforceGrayscale,
+    softEnforcement = softEnforcement,
+)
+
+private fun ProfileDto.toEntity() = FocusProfileEntity(
+    id = id,
+    name = name,
+    preset = preset,
+    useTierA = useTierA,
+    useTierB = useTierB,
+    useTierC = useTierC,
+    strictBrowserLock = strictBrowserLock,
+    enforceGrayscale = enforceGrayscale,
+    softEnforcement = softEnforcement,
+)
+
+private fun DomainRuleEntity.toDto() = DomainRuleDto(
+    id = id,
+    pattern = pattern,
+    isAllowlist = isAllowlist,
+)
+
+private fun DomainRuleDto.toEntity() = DomainRuleEntity(
+    id = id,
+    pattern = pattern,
+    isAllowlist = isAllowlist,
+)
+
+private fun AppBudgetEntity.toDto() = AppBudgetDto(
+    packageName = packageName,
+    maxMinutesPerDay = maxMinutesPerDay,
+    maxOpensPerDay = maxOpensPerDay,
+)
+
+private fun AppBudgetDto.toEntity() = AppBudgetEntity(
+    packageName = packageName,
+    maxMinutesPerDay = maxMinutesPerDay,
+    maxOpensPerDay = maxOpensPerDay,
+)
+
+private fun BreakPolicyEntity.toDto() = BreakPolicyDto(
+    maxBreaksPerDay = maxBreaksPerDay,
+    breakDurationMinutes = breakDurationMinutes,
+    minGapBetweenBreaksMinutes = minGapBetweenBreaksMinutes,
+)
+
+private fun BreakPolicyDto.toEntity() = BreakPolicyEntity(
+    id = 1,
+    maxBreaksPerDay = maxBreaksPerDay,
+    breakDurationMinutes = breakDurationMinutes,
+    minGapBetweenBreaksMinutes = minGapBetweenBreaksMinutes,
+)

--- a/app/src/main/java/com/safephone/data/CloudSyncPreferences.kt
+++ b/app/src/main/java/com/safephone/data/CloudSyncPreferences.kt
@@ -1,0 +1,137 @@
+package com.safephone.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.safephone.BuildConfig
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import java.util.UUID
+
+private val Context.cloudSyncDataStore: DataStore<Preferences> by preferencesDataStore(name = "cloud_sync_prefs")
+
+/**
+ * Persistent settings + state for the cloud-sync feature.
+ *
+ * Stored in a dedicated DataStore (separate from [FocusPreferences]) so that policy snapshots
+ * captured for sync never include the credentials that would gate sync itself.
+ */
+class CloudSyncPreferences(
+    private val context: Context,
+    /**
+     * Build-time default applied when the user hasn't entered their own token. Wired to
+     * [BuildConfig.CLOUD_SYNC_DEFAULT_GITHUB_TOKEN] in production; tests can override.
+     */
+    private val defaultGitHubToken: String = BuildConfig.CLOUD_SYNC_DEFAULT_GITHUB_TOKEN,
+    /**
+     * Build-time default gist id so a fresh install knows which remote document to pull from before
+     * the user has pushed once. Wired to [BuildConfig.CLOUD_SYNC_DEFAULT_GIST_ID] in production.
+     */
+    private val defaultGistId: String = BuildConfig.CLOUD_SYNC_DEFAULT_GIST_ID,
+) {
+
+    /** User-entered token or, if blank, the baked-in build default. The pref is the source of truth when set. */
+    val gitHubToken: Flow<String> = context.cloudSyncDataStore.data.map { prefs ->
+        prefs[KEY_GH_TOKEN].orEmpty().ifEmpty { defaultGitHubToken }
+    }
+    /** User-entered gist id or, if blank, the baked-in build default. */
+    val gistId: Flow<String> = context.cloudSyncDataStore.data.map { prefs ->
+        prefs[KEY_GIST_ID].orEmpty().ifEmpty { defaultGistId }
+    }
+    /** Token the user explicitly typed in this device (no default fallback) — used to drive the password field UI. */
+    val userEnteredGitHubToken: Flow<String> =
+        context.cloudSyncDataStore.data.map { it[KEY_GH_TOKEN].orEmpty() }
+    /** Gist id the user explicitly typed in this device (no default fallback). */
+    val userEnteredGistId: Flow<String> =
+        context.cloudSyncDataStore.data.map { it[KEY_GIST_ID].orEmpty() }
+    val autoPullOnLaunch: Flow<Boolean> =
+        context.cloudSyncDataStore.data.map { it[KEY_AUTO_PULL] ?: true }
+    val autoPushOnChange: Flow<Boolean> =
+        context.cloudSyncDataStore.data.map { it[KEY_AUTO_PUSH] ?: true }
+    val lastSyncEpochMs: Flow<Long> = context.cloudSyncDataStore.data.map { it[KEY_LAST_SYNC] ?: 0L }
+    val lastSyncDirection: Flow<String> =
+        context.cloudSyncDataStore.data.map { it[KEY_LAST_SYNC_DIR].orEmpty() }
+    val lastSyncMessage: Flow<String> =
+        context.cloudSyncDataStore.data.map { it[KEY_LAST_SYNC_MSG].orEmpty() }
+
+    /** True when [BuildConfig.CLOUD_SYNC_DEFAULT_GITHUB_TOKEN] was set at build time. UI uses this as a hint. */
+    val hasDefaultGitHubToken: Boolean get() = defaultGitHubToken.isNotEmpty()
+
+    /** True when [BuildConfig.CLOUD_SYNC_DEFAULT_GIST_ID] was set at build time. UI uses this as a hint. */
+    val hasDefaultGistId: Boolean get() = defaultGistId.isNotEmpty()
+
+    /** Stable per-install identifier embedded into snapshots so each device knows which writes were its own. */
+    suspend fun deviceId(): String {
+        val existing = context.cloudSyncDataStore.data.map { it[KEY_DEVICE_ID].orEmpty() }.first()
+        if (existing.isNotEmpty()) return existing
+        val fresh = UUID.randomUUID().toString()
+        context.cloudSyncDataStore.edit { it[KEY_DEVICE_ID] = fresh }
+        return fresh
+    }
+
+    suspend fun snapshot(): Snapshot {
+        val data = context.cloudSyncDataStore.data.first()
+        return Snapshot(
+            gitHubToken = data[KEY_GH_TOKEN].orEmpty().ifEmpty { defaultGitHubToken },
+            gistId = data[KEY_GIST_ID].orEmpty().ifEmpty { defaultGistId },
+            autoPullOnLaunch = data[KEY_AUTO_PULL] ?: true,
+            autoPushOnChange = data[KEY_AUTO_PUSH] ?: true,
+        )
+    }
+
+    suspend fun setGitHubToken(token: String) {
+        context.cloudSyncDataStore.edit { prefs ->
+            val trimmed = token.trim()
+            if (trimmed.isEmpty()) prefs.remove(KEY_GH_TOKEN) else prefs[KEY_GH_TOKEN] = trimmed
+        }
+    }
+
+    suspend fun setGistId(id: String) {
+        context.cloudSyncDataStore.edit { prefs ->
+            val trimmed = id.trim()
+            if (trimmed.isEmpty()) prefs.remove(KEY_GIST_ID) else prefs[KEY_GIST_ID] = trimmed
+        }
+    }
+
+    suspend fun setAutoPullOnLaunch(value: Boolean) {
+        context.cloudSyncDataStore.edit { it[KEY_AUTO_PULL] = value }
+    }
+
+    suspend fun setAutoPushOnChange(value: Boolean) {
+        context.cloudSyncDataStore.edit { it[KEY_AUTO_PUSH] = value }
+    }
+
+    suspend fun recordSyncResult(epochMs: Long, direction: String, message: String) {
+        context.cloudSyncDataStore.edit { prefs ->
+            prefs[KEY_LAST_SYNC] = epochMs
+            prefs[KEY_LAST_SYNC_DIR] = direction
+            prefs[KEY_LAST_SYNC_MSG] = message
+        }
+    }
+
+    data class Snapshot(
+        val gitHubToken: String,
+        val gistId: String,
+        val autoPullOnLaunch: Boolean,
+        val autoPushOnChange: Boolean,
+    ) {
+        val isConfigured: Boolean get() = gitHubToken.isNotEmpty()
+    }
+
+    companion object {
+        private val KEY_GH_TOKEN = stringPreferencesKey("github_token")
+        private val KEY_GIST_ID = stringPreferencesKey("gist_id")
+        private val KEY_AUTO_PULL = booleanPreferencesKey("auto_pull_on_launch")
+        private val KEY_AUTO_PUSH = booleanPreferencesKey("auto_push_on_change")
+        private val KEY_LAST_SYNC = longPreferencesKey("last_sync_epoch_ms")
+        private val KEY_LAST_SYNC_DIR = stringPreferencesKey("last_sync_direction")
+        private val KEY_LAST_SYNC_MSG = stringPreferencesKey("last_sync_message")
+        private val KEY_DEVICE_ID = stringPreferencesKey("device_id")
+    }
+}

--- a/app/src/main/java/com/safephone/data/Daos.kt
+++ b/app/src/main/java/com/safephone/data/Daos.kt
@@ -24,6 +24,9 @@ interface FocusProfileDao {
 
     @Query("DELETE FROM profiles WHERE id = :id")
     suspend fun delete(id: Long)
+
+    @Query("DELETE FROM profiles")
+    suspend fun deleteAll()
 }
 
 @Dao
@@ -39,6 +42,9 @@ interface BlockedAppDao {
 
     @Query("DELETE FROM blocked_apps WHERE packageName = :packageName")
     suspend fun delete(packageName: String)
+
+    @Query("DELETE FROM blocked_apps")
+    suspend fun deleteAll()
 }
 
 @Dao
@@ -54,6 +60,9 @@ interface DomainRuleDao {
 
     @Query("DELETE FROM domain_rules WHERE id = :id")
     suspend fun delete(id: Long)
+
+    @Query("DELETE FROM domain_rules")
+    suspend fun deleteAll()
 }
 
 @Dao
@@ -69,6 +78,9 @@ interface AppBudgetDao {
 
     @Query("DELETE FROM app_budgets WHERE packageName = :packageName")
     suspend fun delete(packageName: String)
+
+    @Query("DELETE FROM app_budgets")
+    suspend fun deleteAll()
 }
 
 @Dao
@@ -96,6 +108,9 @@ interface CalendarKeywordDao {
 
     @Query("DELETE FROM calendar_keywords WHERE keyword = :keyword")
     suspend fun delete(keyword: String)
+
+    @Query("DELETE FROM calendar_keywords")
+    suspend fun deleteAll()
 }
 
 @Dao

--- a/app/src/main/java/com/safephone/ui/MainActivity.kt
+++ b/app/src/main/java/com/safephone/ui/MainActivity.kt
@@ -53,6 +53,7 @@ import androidx.compose.material.icons.outlined.Coffee
 import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.CalendarMonth
+import androidx.compose.material.icons.outlined.CloudSync
 import androidx.compose.material.icons.outlined.UploadFile
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -115,6 +116,8 @@ import com.safephone.data.DomainRuleEntity
 import com.safephone.data.SocialMediaCategory
 import com.safephone.github.VibeCodingGitHub
 import java.time.DayOfWeek
+import com.safephone.cloud.CloudSyncStatus
+import com.safephone.cloud.SyncDirection
 import com.safephone.export.RulesExporter
 import com.safephone.service.BreakManager
 import com.safephone.service.FocusEnforcementService
@@ -230,6 +233,11 @@ class MainActivity : ComponentActivity() {
                     composable("export") {
                         FeatureScaffold(nav, "Export rules") { padding ->
                             ExportRoute(app, Modifier.padding(padding))
+                        }
+                    }
+                    composable("cloud_sync") {
+                        FeatureScaffold(nav, "Cloud sync") { padding ->
+                            CloudSyncRoute(app, Modifier.padding(padding))
                         }
                     }
                     composable("block_stats") {
@@ -450,6 +458,7 @@ private fun HomeRoute(nav: androidx.navigation.NavController, app: SafePhoneApp)
         HomeDestination("weekday_schedule", "Weekday schedule", "Days when rules apply", Icons.Outlined.CalendarMonth),
         HomeDestination("breaks", "Break policy", "How breaks work", Icons.Outlined.Coffee),
         HomeDestination("export", "Export rules", "Share JSON backup", Icons.Outlined.UploadFile),
+        HomeDestination("cloud_sync", "Cloud sync", "Back up policy to a GitHub Gist", Icons.Outlined.CloudSync),
         HomeDestination(
             "system_grayscale",
             "Grayscale display",
@@ -478,6 +487,7 @@ private fun HomeRoute(nav: androidx.navigation.NavController, app: SafePhoneApp)
             "weekday_schedule" to SafePhoneTestTags.HOME_NAV_WEEKDAY_SCHEDULE,
             "breaks" to SafePhoneTestTags.HOME_NAV_BREAKS,
             "export" to SafePhoneTestTags.HOME_NAV_EXPORT,
+            "cloud_sync" to SafePhoneTestTags.HOME_NAV_CLOUD_SYNC,
             "system_grayscale" to SafePhoneTestTags.HOME_NAV_SYSTEM_GRAYSCALE,
             "vibe_coding" to SafePhoneTestTags.HOME_NAV_VIBE_CODING,
         )
@@ -1925,4 +1935,206 @@ private fun ExportRoute(app: SafePhoneApp, modifier: Modifier = Modifier) {
             }
         }
     }
+}
+
+@Composable
+private fun CloudSyncRoute(app: SafePhoneApp, modifier: Modifier = Modifier) {
+    val cloudPrefs = app.cloudSyncPrefs
+    val manager = app.cloudSyncManager
+    val scope = rememberCoroutineScope()
+
+    // Bind input fields to the user-entered values (no BuildConfig fallback) so a baked-in default
+    // token never appears in cleartext in the password field. The resolved values that include the
+    // fallback are used only for the enabled-state of the action buttons.
+    val userToken by cloudPrefs.userEnteredGitHubToken.collectAsState(initial = "")
+    val userGistId by cloudPrefs.userEnteredGistId.collectAsState(initial = "")
+    val autoPull by cloudPrefs.autoPullOnLaunch.collectAsState(initial = true)
+    val autoPush by cloudPrefs.autoPushOnChange.collectAsState(initial = true)
+    val lastSyncMs by cloudPrefs.lastSyncEpochMs.collectAsState(initial = 0L)
+    val lastSyncDir by cloudPrefs.lastSyncDirection.collectAsState(initial = "")
+    val lastSyncMsg by cloudPrefs.lastSyncMessage.collectAsState(initial = "")
+    val status by manager.status.collectAsState()
+
+    var tokenDraft by remember(userToken) { mutableStateOf(userToken) }
+    var gistIdDraft by remember(userGistId) { mutableStateOf(userGistId) }
+
+    val tokenAvailable = tokenDraft.isNotBlank() || cloudPrefs.hasDefaultGitHubToken
+    val gistIdAvailable = gistIdDraft.isNotBlank() || cloudPrefs.hasDefaultGistId
+
+    Column(
+        modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        Text(
+            "Save your full SafePhone policy (blocked apps, domain rules, daily budgets, break " +
+                "policy, calendar keywords, and related preferences) to a private GitHub Gist so " +
+                "you can sync it across your own devices.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            "Create a Personal Access Token at github.com/settings/tokens with the \"gist\" scope, " +
+                "paste it here, then tap Push. The first push creates a private gist; subsequent " +
+                "pushes update it. On a new device, paste the same token plus the gist id and tap Pull.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        OutlinedTextField(
+            value = tokenDraft,
+            onValueChange = { tokenDraft = it },
+            label = { Text("GitHub Personal Access Token") },
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(SafePhoneTestTags.CLOUD_SYNC_TOKEN_FIELD),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Password,
+                capitalization = KeyboardCapitalization.None,
+            ),
+            supportingText = if (tokenDraft.isBlank() && cloudPrefs.hasDefaultGitHubToken) {
+                { Text("Using token baked into this build") }
+            } else {
+                null
+            },
+        )
+        OutlinedTextField(
+            value = gistIdDraft,
+            onValueChange = { gistIdDraft = it },
+            label = { Text("Gist id (leave empty to create on first push)") },
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(SafePhoneTestTags.CLOUD_SYNC_GIST_ID_FIELD),
+            keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.None),
+            supportingText = if (gistIdDraft.isBlank() && cloudPrefs.hasDefaultGistId) {
+                { Text("Using gist id baked into this build") }
+            } else {
+                null
+            },
+        )
+
+        OutlinedButton(
+            onClick = {
+                scope.launch {
+                    cloudPrefs.setGitHubToken(tokenDraft)
+                    cloudPrefs.setGistId(gistIdDraft)
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = tokenDraft != userToken || gistIdDraft != userGistId,
+        ) { Text("Save credentials") }
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Button(
+                onClick = {
+                    scope.launch {
+                        cloudPrefs.setGitHubToken(tokenDraft)
+                        cloudPrefs.setGistId(gistIdDraft)
+                        manager.pushNow()
+                    }
+                },
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag(SafePhoneTestTags.CLOUD_SYNC_PUSH),
+                enabled = status !is CloudSyncStatus.InProgress && tokenAvailable,
+            ) { Text("Push to cloud") }
+            OutlinedButton(
+                onClick = {
+                    scope.launch {
+                        cloudPrefs.setGitHubToken(tokenDraft)
+                        cloudPrefs.setGistId(gistIdDraft)
+                        manager.pullNow()
+                    }
+                },
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag(SafePhoneTestTags.CLOUD_SYNC_PULL),
+                enabled = status !is CloudSyncStatus.InProgress &&
+                    tokenAvailable &&
+                    gistIdAvailable,
+            ) { Text("Pull from cloud") }
+        }
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+        ) {
+            Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text("Auto-pull on app launch", style = MaterialTheme.typography.bodyMedium)
+                    Switch(
+                        checked = autoPull,
+                        onCheckedChange = { v -> scope.launch { cloudPrefs.setAutoPullOnLaunch(v) } },
+                        modifier = Modifier.testTag(SafePhoneTestTags.CLOUD_SYNC_AUTO_PULL_TOGGLE),
+                    )
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text("Auto-push on policy change", style = MaterialTheme.typography.bodyMedium)
+                    Switch(
+                        checked = autoPush,
+                        onCheckedChange = { v -> scope.launch { cloudPrefs.setAutoPushOnChange(v) } },
+                        modifier = Modifier.testTag(SafePhoneTestTags.CLOUD_SYNC_AUTO_PUSH_TOGGLE),
+                    )
+                }
+            }
+        }
+
+        val statusText = renderCloudSyncStatus(status, lastSyncMs, lastSyncDir, lastSyncMsg)
+        Text(
+            statusText,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.testTag(SafePhoneTestTags.CLOUD_SYNC_STATUS_TEXT),
+        )
+    }
+}
+
+private fun renderCloudSyncStatus(
+    status: CloudSyncStatus,
+    lastSyncMs: Long,
+    lastSyncDir: String,
+    lastSyncMsg: String,
+): String {
+    val current = when (status) {
+        is CloudSyncStatus.Idle -> "Idle"
+        is CloudSyncStatus.InProgress -> when (status.direction) {
+            SyncDirection.Pull -> "Pulling…"
+            SyncDirection.Push -> "Pushing…"
+        }
+        is CloudSyncStatus.Success -> when (status.direction) {
+            SyncDirection.Pull -> "Pull OK: ${status.message}"
+            SyncDirection.Push -> "Push OK: ${status.message}"
+        }
+        is CloudSyncStatus.Failure -> "Failed: ${status.message}"
+    }
+    val tail = if (lastSyncMs > 0L) {
+        val ago = System.currentTimeMillis() - lastSyncMs
+        val minutes = (ago / 60_000L).coerceAtLeast(0)
+        val pretty = when {
+            ago < 30_000L -> "just now"
+            minutes < 60 -> "$minutes min ago"
+            minutes < 60 * 24 -> "${minutes / 60}h ago"
+            else -> "${minutes / (60 * 24)}d ago"
+        }
+        "Last $lastSyncDir: $pretty${if (lastSyncMsg.isNotBlank()) " — $lastSyncMsg" else ""}"
+    } else {
+        "No sync yet"
+    }
+    return "$current\n$tail"
 }

--- a/app/src/main/java/com/safephone/ui/SafePhoneTestTags.kt
+++ b/app/src/main/java/com/safephone/ui/SafePhoneTestTags.kt
@@ -46,4 +46,12 @@ object SafePhoneTestTags {
     const val EXPORT_GENERATE = "export_generate"
     const val EXPORT_SHARE = "export_share"
     const val EXPORT_JSON_TEXT = "export_json_text"
+    const val HOME_NAV_CLOUD_SYNC = "home_nav_cloud_sync"
+    const val CLOUD_SYNC_TOKEN_FIELD = "cloud_sync_token_field"
+    const val CLOUD_SYNC_GIST_ID_FIELD = "cloud_sync_gist_id_field"
+    const val CLOUD_SYNC_PUSH = "cloud_sync_push"
+    const val CLOUD_SYNC_PULL = "cloud_sync_pull"
+    const val CLOUD_SYNC_AUTO_PULL_TOGGLE = "cloud_sync_auto_pull_toggle"
+    const val CLOUD_SYNC_AUTO_PUSH_TOGGLE = "cloud_sync_auto_push_toggle"
+    const val CLOUD_SYNC_STATUS_TEXT = "cloud_sync_status_text"
 }

--- a/app/src/test/java/com/safephone/cloud/PolicySnapshotRepositoryTest.kt
+++ b/app/src/test/java/com/safephone/cloud/PolicySnapshotRepositoryTest.kt
@@ -1,0 +1,183 @@
+package com.safephone.cloud
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.safephone.data.AppBudgetEntity
+import com.safephone.data.AppDatabase
+import com.safephone.data.BlockedAppEntity
+import com.safephone.data.BreakPolicyEntity
+import com.safephone.data.CalendarKeywordEntity
+import com.safephone.data.DomainRuleEntity
+import com.safephone.data.FocusPreferences
+import com.safephone.data.FocusProfileEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class PolicySnapshotRepositoryTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var prefs: FocusPreferences
+    private lateinit var repo: PolicySnapshotRepository
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        db = AppDatabase.createInMemory(context)
+        prefs = FocusPreferences(context)
+        repo = PolicySnapshotRepository(db, prefs)
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun capture_includes_all_synced_fields() = runBlocking {
+        seedAll()
+        val snap = repo.capture(deviceId = "dev-A", nowMs = 1_700_000_000_000L)
+
+        assertEquals(PolicySnapshot.CURRENT_SCHEMA_VERSION, snap.schemaVersion)
+        assertEquals("dev-A", snap.deviceId)
+        assertEquals(1_700_000_000_000L, snap.updatedAtMs)
+        assertEquals(listOf("com.alpha", "com.zulu"), snap.blockedApps)
+        assertEquals(2, snap.domainRules.size)
+        assertEquals(listOf("focus", "review"), snap.calendarKeywords)
+        assertEquals(15, snap.breakPolicy.breakDurationMinutes)
+        assertEquals(3, snap.breakPolicy.maxBreaksPerDay)
+        assertEquals(1, snap.appBudgets.size)
+        assertEquals("com.budgeted", snap.appBudgets.first().packageName)
+        assertEquals(true, snap.prefs.calendarAware)
+        assertEquals(setOf(1, 2, 3, 4, 5).toList().sorted(), snap.prefs.activeDaysOfWeek)
+        assertEquals(listOf("com.mindful"), snap.prefs.mindfulFrictionPackages)
+    }
+
+    @Test
+    fun apply_replaces_local_state_with_snapshot() = runBlocking {
+        seedAll()
+        val captured = repo.capture(deviceId = "dev-A", nowMs = 1L)
+        val json = repo.toJson(captured)
+        assertNotNull(repo.fromJson(json))
+
+        wipeAndSeedDifferent()
+        val parsed = repo.fromJson(json)!!
+        val applyResult = repo.apply(parsed)
+        assertEquals(PolicySnapshotRepository.ApplyResult.Applied, applyResult)
+
+        val recaptured = repo.capture(deviceId = "dev-A", nowMs = 2L)
+        // Re-captured snapshot equals the original modulo timestamp/device fields.
+        assertEquals(captured.copy(updatedAtMs = 2L), recaptured)
+    }
+
+    @Test
+    fun apply_rejects_newer_schema() = runBlocking {
+        val futureSnap = PolicySnapshot(
+            schemaVersion = PolicySnapshot.CURRENT_SCHEMA_VERSION + 1,
+            deviceId = "dev-future",
+            updatedAtMs = 1L,
+            profiles = emptyList(),
+            blockedApps = emptyList(),
+            domainRules = emptyList(),
+            appBudgets = emptyList(),
+            breakPolicy = BreakPolicyDto(5, 10, 30),
+            calendarKeywords = emptyList(),
+            prefs = PrefsDto(
+                enforcementEnabled = true,
+                activeProfileId = null,
+                aggressivePoll = true,
+                notificationHints = false,
+                calendarAware = false,
+                mindfulFrictionPackages = emptyList(),
+                systemMonochromeAutomationEnabled = true,
+                socialMediaCategoryBlocked = false,
+                partnerBlockAlertEnabled = false,
+                partnerBlockAlertThreshold = 5,
+                partnerAlertPhoneDigits = "",
+                activeDaysOfWeek = listOf(1, 2, 3, 4, 5, 6, 7),
+            ),
+        )
+        val res = repo.apply(futureSnap)
+        assertTrue(res is PolicySnapshotRepository.ApplyResult.SchemaTooNew)
+    }
+
+    @Test
+    fun fromJson_returns_null_for_garbage() {
+        assertEquals(null, repo.fromJson("not json"))
+        assertEquals(null, repo.fromJson("{\"schemaVersion\": 1}"))
+    }
+
+    private suspend fun seedAll() {
+        db.focusProfileDao().insert(
+            FocusProfileEntity(
+                id = 7L,
+                name = "Deep work",
+                preset = "DEEP_WORK",
+                useTierA = true,
+                useTierB = true,
+                useTierC = false,
+                strictBrowserLock = true,
+                enforceGrayscale = false,
+                softEnforcement = false,
+            ),
+        )
+        db.blockedAppDao().upsert(BlockedAppEntity("com.alpha"))
+        db.blockedAppDao().upsert(BlockedAppEntity("com.zulu"))
+        db.domainRuleDao().upsert(DomainRuleEntity(id = 1, pattern = "twitter.com", isAllowlist = false))
+        db.domainRuleDao().upsert(DomainRuleEntity(id = 2, pattern = ".docs.corp", isAllowlist = true))
+        db.appBudgetDao().upsert(
+            AppBudgetEntity(packageName = "com.budgeted", maxMinutesPerDay = 30, maxOpensPerDay = 5),
+        )
+        db.breakPolicyDao().upsert(
+            BreakPolicyEntity(
+                id = 1,
+                maxBreaksPerDay = 3,
+                breakDurationMinutes = 15,
+                minGapBetweenBreaksMinutes = 45,
+            ),
+        )
+        db.calendarKeywordDao().upsert(CalendarKeywordEntity("focus"))
+        db.calendarKeywordDao().upsert(CalendarKeywordEntity("review"))
+
+        prefs.setEnforcementEnabled(true)
+        prefs.setActiveProfileId(7L)
+        prefs.setAggressivePoll(false)
+        prefs.setNotificationHints(true)
+        prefs.setCalendarAware(true)
+        prefs.setMindfulFrictionPackages(setOf("com.mindful"))
+        prefs.setSystemMonochromeAutomationEnabled(false)
+        prefs.setSocialMediaCategoryBlocked(true)
+        prefs.setPartnerBlockAlertEnabled(true)
+        prefs.setPartnerBlockAlertThreshold(7)
+        prefs.setPartnerAlertPhoneDigits("+14155552671")
+        prefs.setActiveDaysOfWeek(setOf(1, 2, 3, 4, 5))
+
+        // Sanity check that prefs writes flushed.
+        assertEquals(7L, prefs.activeProfileId.first())
+    }
+
+    private suspend fun wipeAndSeedDifferent() {
+        db.focusProfileDao().deleteAll()
+        db.blockedAppDao().deleteAll()
+        db.domainRuleDao().deleteAll()
+        db.appBudgetDao().deleteAll()
+        db.calendarKeywordDao().deleteAll()
+        db.breakPolicyDao().upsert(BreakPolicyEntity())
+        db.blockedAppDao().upsert(BlockedAppEntity("com.unrelated"))
+        prefs.setEnforcementEnabled(false)
+        prefs.setActiveProfileId(null)
+        prefs.setMindfulFrictionPackages(emptySet())
+        prefs.setActiveDaysOfWeek((1..7).toSet())
+    }
+}

--- a/local.properties.example
+++ b/local.properties.example
@@ -1,2 +1,17 @@
 # Copy to local.properties and set your Android SDK path.
 sdk.dir=/path/to/Android/sdk
+
+# Cloud-sync defaults (GitHub Gist token + gist id) are normally injected by CI
+# from GitHub Actions secrets — see .github/workflows/android-branch-apk.yml and
+# the CLOUD_SYNC_DEFAULT_GITHUB_TOKEN / CLOUD_SYNC_DEFAULT_GIST_ID repo secrets.
+# Production APKs built by CD already have them baked into BuildConfig, so devices
+# never need to enter a token in the UI.
+#
+# The two lines below are only useful if you want to test a locally-built APK
+# without going through CI. They MUST live in `local.properties` (gitignored),
+# never in this `*.example` file. Anyone with the resulting APK can extract
+# whatever token you bake in, so use a short-lived fine-grained PAT with only
+# the "Gists" permission and revoke it as soon as the APK leaves your machine.
+#
+# safephone.cloudSyncDefaultGitHubToken=github_pat_xxx
+# safephone.cloudSyncDefaultGistId=abc123def456


### PR DESCRIPTION
## Summary

Adds a single-global-policy cloud sync layer backed by a private GitHub Gist, plus the CD plumbing so devices never need to enter a token in the app.

- **New Cloud sync screen** with Save / Push / Pull buttons, auto-pull-on-launch and debounced auto-push-on-change toggles, and a status line showing the last sync result.
- **`CloudSyncManager`** orchestrates pulls/pushes, observes Room DAOs + `FocusPreferences` for changes, debounces auto-push, and uses a post-pull suppression window so a pull doesn't immediately echo back as a push.
- **`PolicySnapshotRepository`** captures focus profiles, blocked apps, domain rules, app budgets, break policy, calendar keywords, and policy-defining preferences into a versioned JSON DTO and applies it back with replace-all semantics so deletions propagate.
- **`GistClient`** is a tiny `HttpURLConnection` wrapper around the Gist REST API (read / create / update) using the existing reflection-based Moshi setup.
- **Last-write-wins conflict resolution** via snapshot `updatedAtMs` + per-device id; the UI warns when local state is newer than what was pulled.

## Configuration (no in-app setup)

`app/build.gradle.kts` now resolves `CLOUD_SYNC_DEFAULT_GITHUB_TOKEN` / `CLOUD_SYNC_DEFAULT_GIST_ID` BuildConfig fields in this order:

1. Environment variable (CI path — preferred, secrets stay off the gradle command line).
2. `local.properties` (gitignored, optional dev fallback).
3. `-P` gradle flag.

`.github/workflows/android-branch-apk.yml` reads two new repo secrets and exposes them only as env vars on the build step:

```yaml
env:
  SAFEPHONE_CLOUD_SYNC_DEFAULT_GITHUB_TOKEN: ${{ secrets.CLOUD_SYNC_DEFAULT_GITHUB_TOKEN }}
  SAFEPHONE_CLOUD_SYNC_DEFAULT_GIST_ID: ${{ secrets.CLOUD_SYNC_DEFAULT_GIST_ID }}
```

If either secret is unset, BuildConfig falls back to `""` and the Cloud sync screen prompts for manual entry — the app still works.

## Required setup before merging

Add two repository secrets at `Settings -> Secrets and variables -> Actions`:

- `CLOUD_SYNC_DEFAULT_GITHUB_TOKEN` — fine-grained PAT with **only** "Account permissions -> Gists: Read and write".
- `CLOUD_SYNC_DEFAULT_GIST_ID` — the gist id (created once via the app or `curl -X POST https://api.github.com/gists`).

Without them the workflow still runs green; the feature just falls back to manual in-app entry.

## Files

- New: `app/src/main/java/com/safephone/cloud/{CloudSyncManager,GistClient,PolicySnapshot,PolicySnapshotRepository}.kt`
- New: `app/src/main/java/com/safephone/data/CloudSyncPreferences.kt`
- New: `app/src/test/java/com/safephone/cloud/PolicySnapshotRepositoryTest.kt`
- Modified: `app/build.gradle.kts`, `.github/workflows/android-branch-apk.yml`, `SafePhoneApp.kt`, `Daos.kt` (added `deleteAll()` on rule DAOs for replace-all apply), `MainActivity.kt` (cloud sync route + nav entry), `SafePhoneTestTags.kt`, `local.properties.example`.

## Test plan

- [x] `./gradlew :app:assembleInternalRelease` (no daemon) — green.
- [x] `PolicySnapshotRepositoryTest` covers capture/apply round-trip, replace-all on apply, and rejection of newer schema versions.
- [ ] After secrets are added: push to `main`, install the resulting `app-internal-release.apk`, confirm the Cloud sync screen shows "Using build defaults" hints and auto-pulls on first launch with no manual entry.
- [ ] On a second device: edit a focus profile, wait for debounced auto-push, then re-launch the first device and confirm the change appears.
- [ ] With either secret unset on a one-off CI run: confirm the app still builds and the Cloud sync screen falls back to manual token entry.

## Security notes

- Token stays in env vars only — never on the gradle command line, never in any tracked file. `local.properties.example` documents the local fallback but contains no real values.
- Use a short-lived fine-grained PAT scoped to Gists only. Anyone with the APK can extract the baked-in token, so rotate if an APK leaves your control.

Made with [Cursor](https://cursor.com)